### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[test/**/expected.css]
+insert_final_newline = false
+
+[{package.json,.travis.yml,.eslintrc.json}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

See <https://editorconfig.org/>